### PR TITLE
Add local AI skills, scripts, and docs for grSim workflows

### DIFF
--- a/.ai/skills/grsim-build-debug/SKILL.md
+++ b/.ai/skills/grsim-build-debug/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: grsim-build-debug
+description: Use when building grSim, fixing CMake/Qt/OpenGL/ODE/protobuf dependency issues, or validating simulator startup after C++ changes.
+---
+
+# grsim-build-debug
+
+## When to use
+- Build/setup tasks
+- Compiler or linker failures
+- Startup sanity checks after core code changes
+
+## Inputs to gather
+- Host OS and toolchain
+- Full failing command and first error
+- Whether `.proto` or `config/*.ini` changed
+
+## Workflow
+1. Run `scripts/check_deps.sh` to quickly detect missing tools.
+2. Configure a clean build directory.
+3. Build with parallel jobs and capture the first error.
+4. Apply the minimal fix and rebuild.
+5. Run `scripts/sanity_check.sh`.
+
+## Commands
+- `bash .ai/skills/grsim-build-debug/scripts/check_deps.sh`
+- `cmake -S . -B build`
+- `cmake --build build -j`
+- `bash .ai/skills/grsim-build-debug/scripts/sanity_check.sh`
+
+## References
+- `references/common-failures.md`

--- a/.ai/skills/grsim-build-debug/references/common-failures.md
+++ b/.ai/skills/grsim-build-debug/references/common-failures.md
@@ -1,0 +1,9 @@
+# Common build/runtime failures
+
+- **Qt5 not found**: ensure Qt5 Core/Widgets/OpenGL/Network dev packages are installed.
+- **ODE mismatch**: prefer double precision ODE builds.
+- **Protobuf not found**: install protobuf compiler and development libraries.
+- **OpenGL headers missing**: install mesa OpenGL dev packages (Linux) or platform OpenGL SDK.
+- **VarTypes missing**: install globally or allow CMake external project download path.
+
+When multiple failures appear, fix in this order: toolchain -> Qt/OpenGL -> ODE -> protobuf -> project code.

--- a/.ai/skills/grsim-build-debug/scripts/check_deps.sh
+++ b/.ai/skills/grsim-build-debug/scripts/check_deps.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+missing=0
+for cmd in cmake protoc; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "MISSING: $cmd"
+    missing=1
+  else
+    echo "FOUND:   $cmd -> $(command -v "$cmd")"
+  fi
+done
+
+if pkg-config --exists Qt5Core Qt5Widgets Qt5Network; then
+  echo "FOUND:   Qt5 pkg-config entries"
+else
+  echo "WARN:    Qt5 pkg-config entries not found"
+fi
+
+if pkg-config --exists ode; then
+  echo "FOUND:   ODE pkg-config entry"
+else
+  echo "WARN:    ODE pkg-config entry not found"
+fi
+
+exit "$missing"

--- a/.ai/skills/grsim-build-debug/scripts/sanity_check.sh
+++ b/.ai/skills/grsim-build-debug/scripts/sanity_check.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -x ./bin/grSim ]]; then
+  echo "PASS: found executable ./bin/grSim"
+elif [[ -x ./build/grSim ]]; then
+  echo "PASS: found executable ./build/grSim"
+else
+  echo "WARN: grSim binary not found in ./bin or ./build"
+fi
+
+if [[ -f ./config/Parsian.ini ]]; then
+  echo "PASS: config/Parsian.ini exists"
+else
+  echo "FAIL: config/Parsian.ini missing"
+  exit 1
+fi

--- a/.ai/skills/grsim-config-tuning/SKILL.md
+++ b/.ai/skills/grsim-config-tuning/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: grsim-config-tuning
+description: Use when tuning robot geometry/physics INI files and validating behavior changes with reproducible parameter update steps.
+---
+
+# grsim-config-tuning
+
+## When to use
+- Editing `config/*.ini`
+- Investigating robot motion realism or control response
+
+## Workflow
+1. Snapshot baseline config file.
+2. Change one parameter group at a time (geometry, then physics).
+3. Record old/new values and expected effect.
+4. Keep a rollback copy for quick bisect.
+
+## Parameter domains
+- Geometry: dimensions and wheel/kicker placement.
+- Physics: mass/friction/torque related values.
+
+## References
+- `references/parameter-guide.md`

--- a/.ai/skills/grsim-config-tuning/references/parameter-guide.md
+++ b/.ai/skills/grsim-config-tuning/references/parameter-guide.md
@@ -1,0 +1,16 @@
+# Parameter guide
+
+## Geometry
+- `Radius`, `Height`: robot dimensions.
+- `Wheel*Angle`: wheel placement and kinematic response.
+- `Kicker*` fields: kicker dimensions/position.
+
+## Physics
+- `Bodymass`, `Wheelmass`: inertia and acceleration behavior.
+- `Wheel*TangentFriction`, `WheelPerpendicularFriction`: grip/slip behavior.
+- `WheelMotorMaximumApplyingTorque`: acceleration ceiling.
+
+## Tuning strategy
+- Make small changes (5-10%) per run.
+- Evaluate stability and top speed separately.
+- Revert quickly if oscillation increases.

--- a/.ai/skills/grsim-network-diagnostics/SKILL.md
+++ b/.ai/skills/grsim-network-diagnostics/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: grsim-network-diagnostics
+description: Use when diagnosing UDP/network communication issues between grSim, SSL-Vision style consumers, and command/refbox publishers.
+---
+
+# grsim-network-diagnostics
+
+## When to use
+- Simulator not receiving commands
+- Consumers not receiving vision-style packets
+- Team color/port mismatch investigations
+
+## Workflow
+1. Confirm expected sender and receiver endpoints.
+2. Validate protobuf message assumptions in producer/consumer.
+3. Inspect runtime logs and packet counters.
+4. Reproduce with minimal sender/client setup.
+
+## Quick checks
+- Team color flag alignment (`isteamyellow`).
+- Robot IDs in command list are valid.
+- Packet cadence is non-zero and consistent.
+
+## References
+- `references/network-checklist.md`

--- a/.ai/skills/grsim-network-diagnostics/references/network-checklist.md
+++ b/.ai/skills/grsim-network-diagnostics/references/network-checklist.md
@@ -1,0 +1,7 @@
+# Network diagnostics checklist
+
+- Confirm configured ports on both sides.
+- Verify process binding/listening status.
+- Check firewalls or host network isolation.
+- Validate packet schema version expectations.
+- Check robot command content validity (`id`, velocities, spinner/wheels).

--- a/.ai/skills/grsim-proto-workflows/SKILL.md
+++ b/.ai/skills/grsim-proto-workflows/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: grsim-proto-workflows
+description: Use when editing grSim protobuf schemas, validating wire-compatibility, or troubleshooting command packet serialization/deserialization.
+---
+
+# grsim-proto-workflows
+
+## When to use
+- Any change under `src/proto/*.proto`
+- Packet compatibility investigation between simulator and clients
+
+## Workflow
+1. Identify whether field changes are additive or breaking.
+2. Keep field numbers stable; avoid reusing removed tags.
+3. Re-run CMake configure/build to regenerate protobuf C++ sources.
+4. Validate command path assumptions (team color, repeated robot commands, required fields).
+
+## Checklist
+- No renumbering of existing tags
+- Required fields remain intentionally required
+- New optional/repeated fields are backward-compatible
+
+## References
+- `references/compat-rules.md`

--- a/.ai/skills/grsim-proto-workflows/references/compat-rules.md
+++ b/.ai/skills/grsim-proto-workflows/references/compat-rules.md
@@ -1,0 +1,7 @@
+# Protobuf compatibility rules
+
+- Prefer additive changes (`optional`/`repeated`) to preserve compatibility.
+- Never change semantic meaning of existing field numbers.
+- Do not recycle deleted field numbers.
+- Treat changing `required` fields as breaking.
+- Validate downstream usage in both simulator and sample clients.

--- a/.ai/skills/grsim-release-packaging/SKILL.md
+++ b/.ai/skills/grsim-release-packaging/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: grsim-release-packaging
+description: Use when preparing grSim releases, including version updates, platform-specific package generation, and release checklist validation.
+---
+
+# grsim-release-packaging
+
+## When to use
+- Version bumps
+- Packaging and artifact generation
+- Release readiness checks
+
+## Workflow
+1. Confirm version and changelog updates are consistent.
+2. Build in clean environment.
+3. Run packaging target(s) by platform.
+4. Validate artifacts and metadata.
+
+## Platform notes
+- Linux: desktop/icon install and package dependency metadata.
+- macOS: bundle fixup path and bundle metadata.
+- Windows: DLL/config bundling and installer/archive settings.
+
+## References
+- `references/release-checklist.md`

--- a/.ai/skills/grsim-release-packaging/references/release-checklist.md
+++ b/.ai/skills/grsim-release-packaging/references/release-checklist.md
@@ -1,0 +1,8 @@
+# Release checklist
+
+- [ ] Confirm version string is correct.
+- [ ] Build succeeds from clean tree.
+- [ ] Package generation completes for target OS.
+- [ ] Bundle contains app binary + required resources.
+- [ ] License/readme included in final artifact.
+- [ ] Changelog entry added.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,26 @@
+# AGENTS.md instructions for /workspace/grSim
+
+This repository defines local skills for agentic workflows.
+
+## Skills
+A skill is a reusable, task-focused instruction set stored in a `SKILL.md` file.
+
+### Available skills
+- grsim-build-debug: Build, dependency triage, and runtime sanity checks for grSim. (file: `.ai/skills/grsim-build-debug/SKILL.md`)
+- grsim-proto-workflows: Safe protobuf/schema changes and compatibility checks for simulator packets/clients. (file: `.ai/skills/grsim-proto-workflows/SKILL.md`)
+- grsim-config-tuning: Robot geometry and physics tuning with disciplined validation/rollback steps. (file: `.ai/skills/grsim-config-tuning/SKILL.md`)
+- grsim-release-packaging: Version, packaging, and release checklist for Linux/macOS/Windows build flows. (file: `.ai/skills/grsim-release-packaging/SKILL.md`)
+- grsim-network-diagnostics: Diagnose command/vision/refbox networking issues and packet flow assumptions. (file: `.ai/skills/grsim-network-diagnostics/SKILL.md`)
+
+## How to use skills
+- Trigger rules: Use a skill when the user names it explicitly, or when the task clearly matches its description.
+- Progressive disclosure:
+  1) Read only the relevant `SKILL.md` first.
+  2) Open `references/` files only when needed.
+  3) Prefer running `scripts/` when available for repeatable checks.
+- Keep context lean. Do not load unrelated skills.
+- If multiple skills apply, use the minimum set and state the order.
+
+## Safety and fallback
+- If a skill file is missing or stale, state that briefly and continue with best-effort repo-aware guidance.
+- Do not fabricate command output; run commands when verification is needed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,29 @@
+# CLAUDE.md
+
+Repository-local AI workflow guide for Claude Code.
+
+## Local skill catalog
+Claude Code should treat these as reusable playbooks and load the matching `SKILL.md` for the task:
+
+- `.ai/skills/grsim-build-debug/SKILL.md`
+- `.ai/skills/grsim-proto-workflows/SKILL.md`
+- `.ai/skills/grsim-config-tuning/SKILL.md`
+- `.ai/skills/grsim-release-packaging/SKILL.md`
+- `.ai/skills/grsim-network-diagnostics/SKILL.md`
+
+## Invocation guidance
+- If user asks to build/fix compile issues: use **grsim-build-debug**.
+- If user changes `.proto` files or packet behavior: use **grsim-proto-workflows**.
+- If user tunes robot dynamics/INI files: use **grsim-config-tuning**.
+- If user asks for release artifacts/version bumping: use **grsim-release-packaging**.
+- If user asks about UDP packet flow or command reception: use **grsim-network-diagnostics**.
+
+## Execution pattern
+1. Read only the relevant `SKILL.md` files.
+2. Pull in `references/*.md` as needed.
+3. Run helper scripts from `scripts/` for deterministic checks.
+4. Report exact commands and concrete outcomes.
+
+## Notes
+- Keep prompts concise and avoid loading all skills at once.
+- Prefer repository scripts over ad hoc one-off commands when both are available.


### PR DESCRIPTION
### Motivation
- Provide a concise, repository-local catalog of agent skills to standardize common grSim tasks including build/debug, protobuf/schema work, config tuning, networking diagnostics, and release packaging.
- Supply lightweight, repeatable checks and references to speed triage of dependency, startup, and compatibility issues across platforms and toolchains.

### Description
- Add `SKILL.md` entries under `.ai/skills/` for `grsim-build-debug`, `grsim-proto-workflows`, `grsim-config-tuning`, `grsim-network-diagnostics`, and `grsim-release-packaging` to document workflows and checklists. 
- Add reference documents under each skill (`references/*.md`) describing common failures, protobuf compatibility rules, tuning guidance, network checklists, and release checklist. 
- Add small helper scripts `grsim-build-debug/scripts/check_deps.sh` and `grsim-build-debug/scripts/sanity_check.sh` (executable) to perform deterministic dependency and startup checks. 
- Add top-level `AGENTS.md` to define skill invocation rules and `CLAUDE.md` to provide guidance for Claude Code usage with the local skills.

### Testing
- No automated tests were run on these documentation and script additions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7a78e41408331a5c858a924596f6d)